### PR TITLE
Fix: nav bar (bugs and "demo mode" support)

### DIFF
--- a/src/components/nav/Header.module.scss
+++ b/src/components/nav/Header.module.scss
@@ -24,6 +24,13 @@
     }
 }
 
+.logoWrapper{
+    svg{
+        height: 40px;
+        width: 40px;
+    }
+}
+
 @media screen and (min-width: 1024px){
     .headerContainer{
         flex-direction: column;

--- a/src/components/nav/Header.stories.ts
+++ b/src/components/nav/Header.stories.ts
@@ -1,10 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
-import { userEvent, waitFor, within, expect, fn } from '@storybook/test';
+import { userEvent, within, fn } from '@storybook/test';
 
 import { Header } from './Header';
-
-import styles from "../../../components/storybookStyles.module.scss";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -33,19 +31,29 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const DesktopLoggedIn: Story = {
     args: {
-        isLoggedIn: true
-    }   
+        loggedInAs: "jane.doe@businessname.com"
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: 'responsive',
+        }
+    }
 }
 
 export const DesktopLoggedOut: Story = {
     args: {
-        isLoggedIn: false
-    }    
+        loggedInAs: undefined
+    },
+    parameters: {
+        viewport: {
+            defaultViewport: 'responsive',
+        }
+    }  
 };
 
 export const MobileCollapsed: Story = {
     args: {
-        isLoggedIn: true
+        loggedInAs: "jane.doe@businessname.com"
     },
     parameters: {
         viewport: {
@@ -56,7 +64,7 @@ export const MobileCollapsed: Story = {
 
 export const MobileExpandedLoggedIn: Story = {
     args: {
-        isLoggedIn: true
+        loggedInAs: "jane.doe@businessname.com"
     },
     parameters: {
         viewport: {
@@ -75,6 +83,6 @@ export const MobileExpandedLoggedIn: Story = {
 export const MobileExpandedLoggedOut: Story = {
     ...MobileExpandedLoggedIn,
     args: {
-        isLoggedIn: false
+        loggedInAs: undefined
     }
 };

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -8,18 +8,20 @@ import styles from './Header.module.scss';
 
 
 // Nav is not inside the actual header tags for accessibility reasons
-export function Header({ isLoggedIn } : { isLoggedIn : boolean }){
+export function Header({ loggedInAs } : { loggedInAs? : string }){
     return  <div className = {styles.headerContainer} >
                 <header>
                     <Link href={"/"} >
-                        <MyIcon iconID = {'logo'} />
+                        <span className={ styles.logoWrapper }>
+                            <MyIcon iconID = {'logo'} />
+                        </span>
                         <span className = "visuallyHidden">
                             HOME
                         </span>
                     </Link>
                 </header>
                 <NavBar 
-                    isLoggedIn = { isLoggedIn }
+                    loggedInAs = { loggedInAs }
                 />
             </div>
 }

--- a/src/components/nav/NavBar.module.scss
+++ b/src/components/nav/NavBar.module.scss
@@ -111,8 +111,27 @@
     &:active{
         background: var(--mainnav-active-bg);
     }
+
+    svg {
+        height: c.px-to-rem(24);
+        width: c.px-to-rem(24);
+
+        flex-grow: 0;
+        flex-shrink: 0;
+    }
 }
 
+.titleWrapper{
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+}
+
+.subtitle{
+    max-width: calc(80vw - #{c.px-to-rem(24)} - 1rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 @media screen and (min-width: 1000px){
     .menuExpanded{
@@ -140,5 +159,11 @@
         flex-direction: column;
         justify-content: stretch;
         gap: 0.25rem;
+    }
+
+    .subtitle{
+        max-width: 44px;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 }

--- a/src/components/nav/NavBar.tsx
+++ b/src/components/nav/NavBar.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Fragment } from 'react';
 
 import { mergeStyleArraysIntoString } from "../utils"
 import { ICON_ID, Icon } from '../icons/Icons';
@@ -8,12 +9,12 @@ import { useHamburgerMenu } from './useHamburgerMenu';
 import { MutableRefObject, useRef } from 'react';
 
 interface I_NavBar{
-    isLoggedIn : boolean,
+    loggedInAs? : string
 }
 
-export function NavBar({ isLoggedIn } : I_NavBar){
+export function NavBar({ loggedInAs } : I_NavBar){
     const loggedInNav : I_NavItemWrapper[] = [
-        { href: "/logout", iconID: 'logOut', title: "LOG OUT" },
+        { href: "/logout", iconID: 'logOut', title: "LOG OUT", subtitle: loggedInAs },
         { href: "/callEditor", iconID: 'newCall', title: "FRESH HELL" },
         { href: "/calls", iconID: 'calls', title: "CALLS", divider: 'before' },
         { href: "/messages", iconID: 'messages', title: "MSGS", srOnly: "MESSAGES" },
@@ -21,6 +22,7 @@ export function NavBar({ isLoggedIn } : I_NavBar){
         { href: "/deleted", iconID: 'deleted', title: "DELETED" },
     ]
 
+    const isLoggedIn = loggedInAs !== null;
     const navDrawerRef : MutableRefObject<HTMLUListElement | null> = useRef(null);
     const menuButtonRef : MutableRefObject<HTMLButtonElement | null> = useRef(null);
     const { 
@@ -69,6 +71,7 @@ export function NavBar({ isLoggedIn } : I_NavBar){
                                 href = { navData.href }
                                 iconID = { navData.iconID }
                                 title = { navData.title }
+                                subtitle = { navData.subtitle }
                                 srOnly = { navData.srOnly }
                             />
                 })
@@ -83,15 +86,18 @@ interface I_NavItemWrapper {
     iconID : string,
     srOnly? : string,
     stylesIn? : string[],
+    subtitle? : string,
     title? : string,
 }
 
-function NavItemWrapper({ divider, href, iconID, stylesIn, srOnly, title } : I_NavItemWrapper){
+function NavItemWrapper({ divider, href, iconID, srOnly, stylesIn, subtitle, title } : I_NavItemWrapper){
 
     const myStyles = stylesIn === undefined
         ? styles.menuItem
         : mergeStyleArraysIntoString({ passedIn: stylesIn, classesToAdd: [styles.menuItem] })
     ;
+
+    const Wrapper = title && subtitle ? TitleWrapper : Fragment;
 
     return  <>
             { divider && divider === 'before' ? <hr /> : null }
@@ -107,14 +113,29 @@ function NavItemWrapper({ divider, href, iconID, stylesIn, srOnly, title } : I_N
                     </span>
                     : null
             }
+                    <Wrapper>
             { title ?
-                    <span aria-hidden={ srOnly !== undefined }>
-                        { title }
-                    </span>
-                    : null
+                        <span aria-hidden={ srOnly !== undefined }>
+                            { title }
+                        </span>
+                        : null
             }
+            { subtitle ?
+                        <span className={ styles.subtitle }>
+                            { subtitle }
+                        </span>
+                        : null
+            }
+                    </Wrapper>
                 </Link>
             </li>
             { divider && divider === 'after' ? <hr /> : null }
             </>
+}
+
+
+function TitleWrapper({children} : { children : React.ReactNode }){
+    return <div className={ styles.titleWrapper }>
+        { children }
+    </div>
 }


### PR DESCRIPTION
Bugs
* Logo no longer collapses to 0px x 0px
* iPhone viewport no longer persists for desktop-mode stories

Demo Mode support
"Demo mode" will give anonymous users read-only access so they can nose around the program before creating an account. This means there are now three states for a user - logged in, logged out and demo mode.

Since "isLoggedIn" is no longer the deciding factor, the header component now accepts a string, "loggedInAs", instead. The idea is that this string will be the username of logged in users, or "DEMO" for demo moders, but undefined for logged out.